### PR TITLE
fix/script: explicitly specify protocol

### DIFF
--- a/scripts/ps/install_rustup.ps1
+++ b/scripts/ps/install_rustup.ps1
@@ -1,5 +1,6 @@
 $url = "https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-gnu/rustup-init.exe"
 $installer = $env:TEMP + "\rustup-init.exe"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 (New-Object System.Net.WebClient).DownloadFile($url, $installer)
 
 $installer = $installer.Replace("\", "/")


### PR DESCRIPTION
For some reason Powershell wouldn't download the installer without
specifying this explicitly. This didn't happen when I was developing the
box the first time.