### PR TITLE
fix/vm: bug with large machine name

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,6 +40,7 @@ Vagrant.configure("2") do |config|
     windows_slave.vm.provider "virtualbox" do |vb|
       vb.memory = 4096
       vb.gui = true
+      vb.customize ["modifyvm", :id, "--audio", "none"]
     end
   end
 
@@ -56,6 +57,7 @@ Vagrant.configure("2") do |config|
     windows_slave.vm.provider "virtualbox" do |vb|
       vb.memory = 4096
       vb.gui = true
+      vb.customize ["modifyvm", :id, "--audio", "none"]
     end
   end
 
@@ -72,6 +74,7 @@ Vagrant.configure("2") do |config|
     windows_slave.vm.provider "virtualbox" do |vb|
       vb.memory = 4096
       vb.gui = true
+      vb.customize ["modifyvm", :id, "--audio", "none"]
     end
   end
 end


### PR DESCRIPTION
This came up due to this issue:
https://github.com/hashicorp/vagrant/issues/9524

The fix was provided in this thread. It appears to be a VirtualBox issue
rather than Vagrant.

I think it's came up now because I upgraded my version of VirtualBox.