### PR TITLE
macOS Rust Slave

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,5 +70,8 @@ travis_rust_slave-windows-2016-x86_64:
 provision-rust_slave-osx-yosemite-x86_64:
 	ansible-playbook -i environments/vagrant/hosts ansible/osx-rust-slave.yml
 
+clean-rust_slave-osx-yosemite-x86_64:
+	ansible-playbook -i environments/vagrant/hosts ansible/osx-teardown.yml
+
 clean:
 	vagrant destroy -f

--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,12 @@ travis_rust_slave-windows-2016-x86_64:
 	vagrant up travis_rust_slave-windows-2016-x86_64 --provision
 
 provision-rust_slave-osx-yosemite-x86_64:
-	ansible-playbook -i environments/vagrant/hosts ansible/osx-rust-slave.yml
+	# Pipelining must be enabled to get around a problem with permissions and temporary files on OSX:
+	# https://docs.ansible.com/ansible/latest/user_guide/become.html#becoming-an-unprivileged-user
+	ANSIBLE_PIPELINING=True ansible-playbook -i environments/vagrant/hosts ansible/osx-rust-slave.yml
 
 clean-rust_slave-osx-yosemite-x86_64:
-	ansible-playbook -i environments/vagrant/hosts ansible/osx-teardown.yml
+	ANSIBLE_PIPELINING=True ansible-playbook -i environments/vagrant/hosts ansible/osx-teardown.yml
 
 clean:
 	vagrant destroy -f

--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,12 @@ travis_rust_slave-windows-2016-x86_64: export WINDOWS_RUST_SLAVE_URL := ${WINDOW
 travis_rust_slave-windows-2016-x86_64:
 	vagrant up travis_rust_slave-windows-2016-x86_64 --provision
 
-provision-rust_slave-osx-yosemite-x86_64:
+provision-rust_slave-osx-mojave-x86_64:
 	# Pipelining must be enabled to get around a problem with permissions and temporary files on OSX:
 	# https://docs.ansible.com/ansible/latest/user_guide/become.html#becoming-an-unprivileged-user
 	ANSIBLE_PIPELINING=True ansible-playbook -i environments/vagrant/hosts ansible/osx-rust-slave.yml
 
-clean-rust_slave-osx-yosemite-x86_64:
+clean-rust_slave-osx-mojave-x86_64:
 	ANSIBLE_PIPELINING=True ansible-playbook -i environments/vagrant/hosts ansible/osx-teardown.yml
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -67,5 +67,8 @@ travis_rust_slave-windows-2016-x86_64: export WINDOWS_RUST_SLAVE_URL := ${WINDOW
 travis_rust_slave-windows-2016-x86_64:
 	vagrant up travis_rust_slave-windows-2016-x86_64 --provision
 
+provision-rust_slave-osx-yosemite-x86_64:
+	ansible-playbook -i environments/vagrant/hosts ansible/osx-rust-slave.yml
+
 clean:
 	vagrant destroy -f

--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ Our environment contains some macOS slaves that we're running on physical hardwa
 * `xcode-select --install` to install the XCode Developer Tools
 * `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"` to install Homebrew
 * `brew tap homebrew/homebrew-core`
+* Create a ~/.bashrc for the `qamaidsafe` user with `export PATH=/usr/local/bin:$PATH`
 
 You should now be able to establish an SSH connection to this slave.
+
+The last step of those instructions is to make `/usr/local/bin` available for non-login shells, which is what Ansible will have. On macOS the environment is very minimal for non-login shells. Previously I was getting around this by symlinking things into `/usr/bin` (which is on the PATH for non-login shells), but Apple's 'System Integrity Protection' now prevents this directory from being written to, even as root. `/usr/local/bin` is where Homebrew installs most things, so we require this to be on `PATH` for non-login shells.
 
 ## Building Vagrant Boxes
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Our environment contains some macOS slaves that we're running on physical hardwa
 * `xcode-select --install` to install the XCode Developer Tools
 * `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"` to install Homebrew
 * `brew tap homebrew/homebrew-core`
+* Disable PAM authentication by editing `/etc/ssh/sshd_config` and changing `UsePAM yes` to `UsePAM no` (jenkins user can't SSH in without this)
+* Give the `qamaidsafe` user passwordless sudo for Ansible with the [2nd answer here](https://serverfault.com/questions/160581/how-to-setup-passwordless-sudo-on-linux)
 * Create a ~/.bashrc for the `qamaidsafe` user with `export PATH=/usr/local/bin:$PATH`
 
 You should now be able to establish an SSH connection to this slave.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The intention for this Jenkins instance is to use the [Job DSL plugin](https://g
 * Paste the contents of the 'ansible/roles/jenkins-master/files/job_dsl_seed.groovy' file in this repository into the textbox
 * Save the job then run it
 
-After running the seed job, this will generate all the other jobs. At the time of writing there is only a pipeline for [Safe Client Libs](https://github.com/maidsafe/safe_client_libs). Now, if you run the SCL pipeline, the first time it runs it will fail, because some of the Groovy methods being called in the pipeline need approval from a Jenkins administrator. You can do that by going to 'Manage Jenkins' -> 'In-process Script Approval' and click on the 'Approve' button for any methods listed. This should allow the SCL pipeline to run through. After this I would also recommend switching to the [Blue Ocean](https://jenkins.io/projects/blueocean/) view.
+After running the seed job, this will generate all the other jobs. At the time of writing there is only a pipeline for [Safe Client Libs](https://github.com/maidsafe/safe_client_libs). I would recommend switching to the [Blue Ocean](https://jenkins.io/projects/blueocean/) view.
 
 ### macOS Slaves
 

--- a/ansible/osx-rust-slave.yml
+++ b/ansible/osx-rust-slave.yml
@@ -1,0 +1,7 @@
+---
+- hosts: jenkins-osx-slaves
+  become: True
+  roles:
+    - osx-pip
+    - osx-java
+    - jenkins-slave

--- a/ansible/osx-rust-slave.yml
+++ b/ansible/osx-rust-slave.yml
@@ -5,3 +5,4 @@
     - osx-pip
     - osx-java
     - jenkins-slave
+    - rust

--- a/ansible/osx-teardown.yml
+++ b/ansible/osx-teardown.yml
@@ -1,0 +1,34 @@
+---
+- hosts: jenkins-osx-slaves
+  become: True
+  tasks:
+    - name: 'uninstall awscli'
+      pip:
+        name: 'awscli'
+        state: absent
+    - name: 'uninstall pip'
+      pip:
+        name: 'pip'
+        state: absent
+    - name: 'remove jenkins user'
+      user:
+        name: 'jenkins'
+        state: absent
+    - name: 'remove jenkins group'
+      group:
+        name: 'jenkins'
+        state: absent
+    - name: 'remove jenkins user home directory'
+      file:
+        path: /Users/jenkins
+        state: absent
+    - name: 'uninstall java'
+      homebrew_cask:
+        name: java8
+        state: absent
+      become: yes
+      become_user: qa
+    - name: 'uninstall caskroom/versions'
+      homebrew_tap:
+        name: caskroom/versions
+        state: absent

--- a/ansible/roles/jenkins-master/files/job_dsl_seed.groovy
+++ b/ansible/roles/jenkins-master/files/job_dsl_seed.groovy
@@ -1,6 +1,6 @@
 pipelineJob('pipeline-safe_client_libs') {
     parameters {
-        stringParam('BRANCH', 'scl_windows_jenkins_build')
+        stringParam('BRANCH', 'osx_jenkins_build')
         stringParam('IMAGE_NAME', 'maidsafe/safe-client-libs-build')
         stringParam('IMAGE_TAG', '0.9.0')
         stringParam('REPO_URL', 'https://github.com/jacderida/safe_client_libs.git')
@@ -19,7 +19,7 @@ pipelineJob('pipeline-safe_client_libs') {
             scm {
                 git {
                     remote { url('https://github.com/jacderida/safe_client_libs.git') }
-                    branches('scl_windows_jenkins_build')
+                    branches('osx_jenkins_build')
                     scriptPath('scripts/Jenkinsfile')
                     extensions { }
                 }

--- a/ansible/roles/jenkins-master/templates/jenkins.yml
+++ b/ansible/roles/jenkins-master/templates/jenkins.yml
@@ -34,6 +34,19 @@ jenkins:
         remoteFS: "/home/jenkins"
     - permanent:
         launcher:
+          sSHLauncher:
+            credentialsId: "docker_slave_jenkins_user_ssh_key"
+            host: "{{ osx_rust_slave_ip_address }}"
+            launchTimeoutSeconds: 210
+            maxNumRetries: 10
+            port: 22
+            retryWaitTime: 15
+        name: "{{ osx_rust_slave_full_name }}"
+        labelString: "osx"
+        numExecutors: 2
+        remoteFS: "/Users/jenkins"
+    - permanent:
+        launcher:
           jnlp:
             workDirSettings:
               disabled: false

--- a/ansible/roles/jenkins-slave/defaults/main.yml
+++ b/ansible/roles/jenkins-slave/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
 build_user: jenkins
-build_user_home_path: "/home/{{ build_user }}"

--- a/ansible/roles/jenkins-slave/tasks/main.yml
+++ b/ansible/roles/jenkins-slave/tasks/main.yml
@@ -71,6 +71,13 @@
     line: "source ~/.cargo/env"
   when: ansible_distribution == 'MacOSX'
 
+# This is required because the non-login shell on macOS doesn't add this to PATH.
+- name: 'add /usr/local/bin to PATH for build user'
+  lineinfile:
+    path: "{{ build_user_home_path }}/.bashrc"
+    line: "export PATH=/usr/local/bin:$PATH"
+  when: ansible_distribution == 'MacOSX'
+
 - name: 'source ~/.bashrc in bash_profile for build user (osx)'
   lineinfile:
     path: "{{ build_user_home_path }}/.bash_profile"

--- a/ansible/roles/jenkins-slave/tasks/main.yml
+++ b/ansible/roles/jenkins-slave/tasks/main.yml
@@ -1,13 +1,36 @@
 ---
+- name: 'load os specific variables'
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_os_family }}.yml"
+    - "default.yml"
+
+# The '--ignore-installed' flag is required for OSX. See here:
+# https://github.com/pypa/pip/issues/3165
 - name: 'install aws cli for retrieving build artifacts from S3'
   pip:
-    name: "awscli"
+    name: 'awscli'
+    extra_args: '--ignore-installed six'
 
-- name: 'add jenkins user'
+- name: 'add jenkins user (linux)'
   user:
     name: "{{ build_user }}"
     shell: /bin/bash
     groups: 'docker'
+  when: ansible_distribution != 'MacOSX'
+
+- name: 'add jenkins group (osx)'
+  group:
+    name: "{{ build_user }}"
+    state: present
+  when: ansible_distribution == 'MacOSX'
+
+- name: 'add jenkins user (osx)'
+  user:
+    name: "{{ build_user }}"
+    groups: "{{ build_user }}"
+    shell: /bin/bash
+  when: ansible_distribution == 'MacOSX'
 
 - name: 'create ssh directory'
   file:

--- a/ansible/roles/jenkins-slave/tasks/main.yml
+++ b/ansible/roles/jenkins-slave/tasks/main.yml
@@ -46,3 +46,33 @@
     state: present
     key: "{{ lookup('file', '../../../../ssh_keys/docker_build_slave_key.pub')}}"
     manage_dir: false
+
+- name: 'create bashrc for build user'
+  file:
+    path: "{{ build_user_home_path }}/.bashrc"
+    state: touch
+    mode: 0644
+    owner: "{{ build_user }}"
+    group: "{{ build_user }}"
+  when: ansible_distribution == 'MacOSX'
+
+- name: 'create bash_profile for build user'
+  file:
+    path: "{{ build_user_home_path }}/.bash_profile"
+    state: touch
+    mode: 0644
+    owner: "{{ build_user }}"
+    group: "{{ build_user }}"
+  when: ansible_distribution == 'MacOSX'
+
+- name: 'source ~/.cargo/env in bashrc for build user'
+  lineinfile:
+    path: "{{ build_user_home_path }}/.bashrc"
+    line: "source ~/.cargo/env"
+  when: ansible_distribution == 'MacOSX'
+
+- name: 'source ~/.bashrc in bash_profile for build user (osx)'
+  lineinfile:
+    path: "{{ build_user_home_path }}/.bash_profile"
+    line: '[[ -s ~/.bashrc ]] && source ~/.bashrc'
+  when: ansible_distribution == 'MacOSX'

--- a/ansible/roles/jenkins-slave/vars/Darwin.yml
+++ b/ansible/roles/jenkins-slave/vars/Darwin.yml
@@ -1,0 +1,2 @@
+---
+build_user_home_path: "/Users/{{ build_user }}"

--- a/ansible/roles/jenkins-slave/vars/default.yml
+++ b/ansible/roles/jenkins-slave/vars/default.yml
@@ -1,0 +1,2 @@
+---
+build_user_home_path: "/home/{{ build_user }}"

--- a/ansible/roles/osx-java/tasks/main.yml
+++ b/ansible/roles/osx-java/tasks/main.yml
@@ -6,6 +6,13 @@
   become: yes
   become_user: "{{ ansible_user }}"
 
+# Issue here:
+# https://github.com/Homebrew/homebrew-cask-versions/issues/5204
+- name: 'run brew upgrade to resolve downloading issue with installing java8'
+  command: 'brew cask upgrade'
+  become: yes
+  become_user: "{{ ansible_user }}"
+
 - name: 'install java using homebrew'
   homebrew_cask:
     name: java8

--- a/ansible/roles/osx-java/tasks/main.yml
+++ b/ansible/roles/osx-java/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: 'install versions tap with homebrew'
+  homebrew_tap:
+    name: caskroom/versions
+    state: present
+  become: yes
+  become_user: "{{ ansible_user }}"
+
+- name: 'install java using homebrew'
+  homebrew_cask:
+    name: java8
+    state: present
+  become: yes
+  become_user: "{{ ansible_user }}"

--- a/ansible/roles/osx-pip/defaults/main.yml
+++ b/ansible/roles/osx-pip/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+pip_installer_url: https://bootstrap.pypa.io/get-pip.py

--- a/ansible/roles/osx-pip/tasks/main.yml
+++ b/ansible/roles/osx-pip/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: 'download get-pip.py'
+  get_url:
+    url: "{{ pip_installer_url }}"
+    dest: 'get-pip.py'
+  when: ansible_distribution == 'MacOSX'
+
+- name: 'install pip'
+  command: 'python get-pip.py'
+  args:
+    creates: /usr/local/bin/pip
+  when: ansible_distribution == 'MacOSX'
+
+# The OSX slave doesn't have /usr/local/bin on the PATH for remote login shells.
+- name: 'symlink pip to /usr/bin'
+  file:
+    src: /usr/local/bin/pip
+    dest: /usr/bin/pip
+    state: link

--- a/ansible/roles/osx-pip/tasks/main.yml
+++ b/ansible/roles/osx-pip/tasks/main.yml
@@ -2,18 +2,16 @@
 - name: 'download get-pip.py'
   get_url:
     url: "{{ pip_installer_url }}"
-    dest: 'get-pip.py'
+    dest: '/tmp/get-pip.py'
   when: ansible_distribution == 'MacOSX'
 
 - name: 'install pip'
-  command: 'python get-pip.py'
+  command: 'python /tmp/get-pip.py'
   args:
     creates: /usr/local/bin/pip
   when: ansible_distribution == 'MacOSX'
 
-# The OSX slave doesn't have /usr/local/bin on the PATH for remote login shells.
-- name: 'symlink pip to /usr/bin'
+- name: 'delete temporary script'
   file:
-    src: /usr/local/bin/pip
-    dest: /usr/bin/pip
-    state: link
+    path: /tmp/get-pip.py
+    state: absent

--- a/ansible/roles/rust/defaults/main.yml
+++ b/ansible/roles/rust/defaults/main.yml
@@ -1,11 +1,8 @@
 ---
 build_user: jenkins
-build_user_home_path: "/home/{{ build_user }}"
 rust_version: 1.32.0
 cargo_bin_path: "{{ build_user_home_path }}/.cargo/bin"
 cargo_path: "{{ cargo_bin_path }}/cargo"
 cargo_script_path: "{{ cargo_bin_path }}/cargo-script"
 rustup_path: "{{ cargo_bin_path }}/rustup"
 rustc_path: "{{ cargo_bin_path }}/rustc"
-rustup_installer_url: "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"
-rustup_installer_path: "/tmp/rustup-init"

--- a/ansible/roles/rust/tasks/main.yml
+++ b/ansible/roles/rust/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: 'load os specific variables'
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_os_family }}.yml"
+    - "default.yml"
+
 - stat: path="{{ rustc_path }}"
   register: rust_path_result
 
@@ -19,7 +25,7 @@
     - pkg-config
   when: ansible_distribution == 'Ubuntu'
   
-- name: 'get the rustup installer (CentOS)'
+- name: 'get the rustup installer'
   get_url:
     url: "{{ rustup_installer_url }}"
     dest: "{{ rustup_installer_path }}"
@@ -28,13 +34,13 @@
     - rust_path_result.stat.exists == False
     - ansible_distribution == 'CentOS'
 
-  # There is some problem with the get_url module and SSL on Ubuntu 14.04.
+  # There is some problem with the get_url module and SSL on Ubuntu 14.04 and OSX.
   # If you run curl manually it works just fine.
 - name: 'get the rustup installer (Ubuntu)'
   shell: "curl {{ rustup_installer_url }} >> {{ rustup_installer_path }}"
   when:
     - rust_path_result.stat.exists == False
-    - ansible_distribution == 'Ubuntu'
+    - ansible_distribution == 'Ubuntu' or ansible_distribution == 'MacOSX'
 
 - name: 'set rustup script executable (Ubuntu)'
   file:
@@ -42,7 +48,7 @@
     mode: 0775
   when:
     - rust_path_result.stat.exists == False
-    - ansible_distribution == 'Ubuntu'
+    - ansible_distribution == 'Ubuntu' or ansible_distribution == 'MacOSX'
 
 - name: 'run the rustup installer'
   command: "{{ rustup_installer_path }} --default-toolchain {{ rust_version }} --no-modify-path -y"
@@ -54,6 +60,7 @@
   command: "{{ rustup_path }} target add x86_64-unknown-linux-musl"
   become: yes
   become_user: "{{ build_user }}"
+  when: ansible_distribution != 'MacOSX'
 
 - stat: path="{{ cargo_script_path }}"
   register: cargo_script_result

--- a/ansible/roles/rust/vars/Darwin.yml
+++ b/ansible/roles/rust/vars/Darwin.yml
@@ -1,0 +1,4 @@
+---
+rustup_installer_url: "https://static.rust-lang.org/rustup/dist/x86_64-apple-darwin/rustup-init"
+build_user_home_path: "/Users/{{ build_user }}"
+rustup_installer_path: "{{ build_user_home_path }}/rustup-init"

--- a/ansible/roles/rust/vars/default.yml
+++ b/ansible/roles/rust/vars/default.yml
@@ -1,0 +1,4 @@
+---
+build_user_home_path: "/home/{{ build_user }}"
+rustup_installer_url: "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"
+rustup_installer_path: "/tmp/rustup-init"

--- a/environments/vagrant/group_vars/all/vars.yml
+++ b/environments/vagrant/group_vars/all/vars.yml
@@ -10,7 +10,7 @@ windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.centos.local
 windows_rust_slave_working_path: "c:\\jenkins-work"
 osx_rust_slave_ip_address: 192.168.1.188
-osx_rust_slave_full_name: rust_slave-osx-yosemite-x86_64
+osx_rust_slave_full_name: rust_slave-osx-mojave-x86_64
 osx_rust_slave_host_url: rust_slave.centos.local
 jenkins_admin_user: chriso
 secret_jenkins_admin_user_password: !vault |

--- a/environments/vagrant/group_vars/all/vars.yml
+++ b/environments/vagrant/group_vars/all/vars.yml
@@ -9,7 +9,7 @@ windows_rust_slave_ip_address: 192.168.10.102
 windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.centos.local
 windows_rust_slave_working_path: "c:\\jenkins-work"
-osx_rust_slave_ip_address: 192.168.1.188
+osx_rust_slave_ip_address: 192.168.1.65
 osx_rust_slave_full_name: rust_slave-osx-mojave-x86_64
 osx_rust_slave_host_url: rust_slave.centos.local
 jenkins_admin_user: chriso

--- a/environments/vagrant/group_vars/all/vars.yml
+++ b/environments/vagrant/group_vars/all/vars.yml
@@ -9,6 +9,9 @@ windows_rust_slave_ip_address: 192.168.10.102
 windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.centos.local
 windows_rust_slave_working_path: "c:\\jenkins-work"
+osx_rust_slave_ip_address: 192.168.1.188
+osx_rust_slave_full_name: rust_slave-osx-yosemite-x86_64
+osx_rust_slave_host_url: rust_slave.centos.local
 jenkins_admin_user: chriso
 secret_jenkins_admin_user_password: !vault |
   $ANSIBLE_VAULT;1.1;AES256

--- a/environments/vagrant/group_vars/all/vars.yml
+++ b/environments/vagrant/group_vars/all/vars.yml
@@ -9,7 +9,7 @@ windows_rust_slave_ip_address: 192.168.10.102
 windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.centos.local
 windows_rust_slave_working_path: "c:\\jenkins-work"
-osx_rust_slave_ip_address: 192.168.1.65
+osx_rust_slave_ip_address: 192.168.1.190
 osx_rust_slave_full_name: rust_slave-osx-mojave-x86_64
 osx_rust_slave_host_url: rust_slave.centos.local
 jenkins_admin_user: chriso

--- a/environments/vagrant/hosts
+++ b/environments/vagrant/hosts
@@ -6,3 +6,6 @@ docker_slave-centos-7.5-x86_64 ansible_connection=local
 
 [jenkins-windows-slaves]
 travis_rust_slave-windows-2016-x86_64
+
+[jenkins-osx-slaves]
+rust_slave-osx-yosemite-x86_64 ansible_host=192.168.1.188 ansible_user=qa

--- a/environments/vagrant/hosts
+++ b/environments/vagrant/hosts
@@ -8,4 +8,4 @@ docker_slave-centos-7.5-x86_64 ansible_connection=local
 travis_rust_slave-windows-2016-x86_64
 
 [jenkins-osx-slaves]
-rust_slave-osx-mojave-x86_64 ansible_host=192.168.1.65 ansible_user=qamaidsafe
+rust_slave-osx-mojave-x86_64 ansible_host=192.168.1.190 ansible_user=qamaidsafe

--- a/environments/vagrant/hosts
+++ b/environments/vagrant/hosts
@@ -8,4 +8,4 @@ docker_slave-centos-7.5-x86_64 ansible_connection=local
 travis_rust_slave-windows-2016-x86_64
 
 [jenkins-osx-slaves]
-rust_slave-osx-yosemite-x86_64 ansible_host=192.168.1.188 ansible_user=qa
+rust_slave-osx-mojave-x86_64 ansible_host=192.168.1.65 ansible_user=qamaidsafe


### PR DESCRIPTION
Hi Stephen/Calum,

This is for provisioning the macOS slave. It sets up Java, the AWSCLI, a Jenkins user and a Rust installation. Since we can't spin up this slave like a VM, there's a playbook for 'resetting' the machine, which undoes those things.

I also updated the manual instructions for setting up the slave. On Mojave it wouldn't let the `jenkins` user SSH in without disabling PAM authentication for `sshd`. We need to give the `qamaidsafe` user passwordless sudo access for use with Ansible, so I added this too.

You could test this by spinning up Jenkins and making sure a build runs through. As per the last time though, it will take a long time because the Windows machine will need to build from scratch. The macOS build will be fast because I've already ran a build on it and it's a static machine. If you really wanted to you could run the reset playbook with `make clean-rust_slave-osx-mojave-x86_64`, run `make provision-rust_slave-osx-mojave-x86_64`, then spin up Jenkins and run the build.

Cheers,

Chris 