### PR TITLE
SCL Container Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ endif
 		-e "aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}" \
 		-e "ansible_vault_password=$$(cat ~/.ansible/vault-pass)" \
 		-e "safe_build_infrastructure_repo_owner=jacderida" \
-		-e "safe_build_infrastructure_repo_branch=staging" \
+		-e "safe_build_infrastructure_repo_branch=scl_container_update" \
 		-u ansible ansible/ansible-provisioner.yml
 	./scripts/sh/prepare_bastion.sh "staging"
 
@@ -217,6 +217,9 @@ else
 endif
 	cd ../..
 	./scripts/sh/update_machine.sh "ansible_bastion" "prod"
+	# Note: the prod environment is now live, so from now on, please *DO NOT* change
+	# the safe_build_infrastructure_repo_owner and safe_build_infrastructure_repo_branch variables
+	# in this target. They are still OK to change for staging or QA.
 	rm -rf ~/.ansible/tmp
 	echo "Attempting Ansible run against Bastion... (can be 10+ seconds before output)"
 	EC2_INI_PATH=environments/prod/ec2-host.ini ansible-playbook -i environments/prod \

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ box-docker_slave-ubuntu-bionic-x86_64-aws:
 		packer build \
 		-only=amazon-ebs \
 		-var='cloud_environment=prod' \
+		-var "commit_hash=$$(git rev-parse --short HEAD)" \
 		templates/docker_slave-ubuntu-bionic-x86_64.json
 
 box-rust_slave-windows-2016-x86_64-aws:

--- a/ansible/roles/jenkins-master/tasks/main.yml
+++ b/ansible/roles/jenkins-master/tasks/main.yml
@@ -25,7 +25,7 @@
     mode: 0644
 
 - name: 'copy plugins list'
-  copy:
+  template:
     src: plugins.txt
     dest: "{{ customised_jenkins_build_path }}/plugins.txt"
     owner: root

--- a/ansible/roles/jenkins-master/templates/plugins.txt
+++ b/ansible/roles/jenkins-master/templates/plugins.txt
@@ -43,7 +43,9 @@ durable-task:1.28
 ec2:1.42
 email-ext:2.63
 favorite:2.3.2
+{% if cloud_environment == "prod" %}
 ghprb:1.42.0
+{% endif %}
 git:3.9.1
 git-client:2.7.4
 github:1.29.3

--- a/environments/dev/group_vars/all/vars.yml
+++ b/environments/dev/group_vars/all/vars.yml
@@ -5,7 +5,7 @@ jenkins_master_host_url: jenkins_master.ubuntu.local
 docker_slave_ip_address: 192.168.10.101
 docker_slave_full_name: docker_slave-ubuntu-bionic-x86_64
 docker_slave_host_url: docker-slave.ubuntu.local
-docker_slave_ami_id: ami-03850277b53ba7bc5
+docker_slave_ami_id: ami-0c96a5161096cfd71
 windows_rust_slave_ip_address: 192.168.10.102
 windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.ubuntu.local

--- a/environments/prod/group_vars/all/vars.yml
+++ b/environments/prod/group_vars/all/vars.yml
@@ -7,7 +7,7 @@ jenkins_master_host_url: jenkins_master.ubuntu.local
 docker_slave_ip_address: 192.168.10.101
 docker_slave_full_name: docker_slave-ubuntu-bionic-x86_64
 docker_slave_host_url: docker-slave.ubuntu.local
-docker_slave_ami_id: ami-03850277b53ba7bc5
+docker_slave_ami_id: ami-0c96a5161096cfd71
 windows_rust_slave_ip_address: 192.168.10.102
 windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.ubuntu.local

--- a/environments/staging/group_vars/all/vars.yml
+++ b/environments/staging/group_vars/all/vars.yml
@@ -7,7 +7,7 @@ jenkins_master_host_url: jenkins_master.ubuntu.local
 docker_slave_ip_address: 192.168.10.101
 docker_slave_full_name: docker_slave-ubuntu-bionic-x86_64
 docker_slave_host_url: docker-slave.ubuntu.local
-docker_slave_ami_id: ami-03850277b53ba7bc5
+docker_slave_ami_id: ami-0c96a5161096cfd71
 windows_rust_slave_ip_address: 192.168.10.102
 windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.ubuntu.local

--- a/templates/docker_slave-ubuntu-bionic-x86_64.json
+++ b/templates/docker_slave-ubuntu-bionic-x86_64.json
@@ -15,7 +15,7 @@
       "instance_type": "t2.micro",
       "region": "eu-west-2",
       "source_ami": "ami-0883141bc92a74917",
-      "ami_name": "{{user `generated_ami_name`}}-{{user-`commit_hash`}}",
+      "ami_name": "{{user `generated_ami_name`}}-{{user `commit_hash`}}",
       "run_tags": {
         "Name": "docker_slave_001",
         "full_name": "{{user `generated_ami_name`}}",
@@ -111,8 +111,8 @@
       "execute_command": "{{.Vars}} sudo -E bash '{{.Path}}'",
       "inline": [
         "apt-get update -y",
-        "apt-get install -y python",
         "sleep 5",
+        "apt-get install -y python",
         "apt-get install -y python-pip"
       ]
     },

--- a/templates/docker_slave-ubuntu-bionic-x86_64.json
+++ b/templates/docker_slave-ubuntu-bionic-x86_64.json
@@ -15,7 +15,7 @@
       "instance_type": "t2.micro",
       "region": "eu-west-2",
       "source_ami": "ami-0883141bc92a74917",
-      "ami_name": "{{user `generated_ami_name`}}",
+      "ami_name": "{{user `generated_ami_name`}}-{{user-`commit_hash`}}",
       "run_tags": {
         "Name": "docker_slave_001",
         "full_name": "{{user `generated_ami_name`}}",


### PR DESCRIPTION
Hi Stephen,

This closes #69.

I built a new container for SCL that was based on the experimental branch and pushed that to Dockerhub. Since the pulled container is baked into the AMI to save time, we need to use a new AMI, which I've regenerated and have supplied the updated ID.

There does seem to be a good improvement on this in staging:
![mock_linux](https://user-images.githubusercontent.com/1055542/59113490-087e0e00-893d-11e9-95c1-44d331d6f8a8.png)
![integration_linux](https://user-images.githubusercontent.com/1055542/59113782-9fe36100-893d-11e9-8852-7a493853f93b.png)
![mocked_linux](https://user-images.githubusercontent.com/1055542/59113932-f6509f80-893d-11e9-844a-8fc8636807cd.png)

Compared to the times here:
https://jenkins.maidsafe.net/blue/organizations/jenkins/pipeline-safe_client_libs/detail/PR-833/4/pipeline
https://jenkins.maidsafe.net/blue/organizations/jenkins/pipeline-safe_client_libs/detail/experimental/2/pipeline

Cheers,

Chris