### PR TITLE
Disable Reboot for Prod Provision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,6 @@ provision-jenkins-prod-aws:
 		-e "cloud_environment=prod" \
 		-u ansible ansible/haproxy-ssl-config.yml
 	python ./scripts/py/run_ansible_against_windows_slaves.py "prod" "ec2-bastion.ini"
-	./scripts/sh/reboot_all_instances.sh "prod"
 
 provision-rust_slave-macos-mojave-x86_64-vagrant-vbox:
 	ANSIBLE_SSH_PIPELINING=true ansible-playbook -i environments/vagrant/hosts \


### PR DESCRIPTION
Hi Stephen,

This reboot unfortunately wreaked some kind of havoc on the system. The Windows slaves looked like fresh machines and the SSL configuration wasn't working. I had to regenerate the certificate again as it was showing as insecure.

We need a much better understanding of this on the staging environment before we do it again.

Cheers,

Chris