### PR TITLE
Rust Component Updates for Slaves

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,7 +372,7 @@ endif
 provision-rust_slave-macos-high_sierra-x86_64-prod-aws:
 	./scripts/sh/run_ansible_against_mac_slave.sh "prod" "192.168.1.190"
 
-provision-rust_slave-macos-high_sierra-x86_64-prod-aws:
+provision-from_external-rust_slave-macos-high_sierra-x86_64-prod-aws:
 ifndef MACOS_SLAVE_SSH_IP_ADDRESS
 	@echo "The MACOS_SLAVE_SSH_IP_ADDRESS environment variable must be set."
 	@exit 1

--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ provision-jenkins-prod-aws:
 		-u ansible ansible/haproxy-ssl-config.yml
 	python ./scripts/py/run_ansible_against_windows_slaves.py "prod" "ec2-bastion.ini"
 
-provision-rust_slave-macos-mojave-x86_64-vagrant-vbox:
+provision-rust_slave-macos-high_sierra-x86_64-vagrant-vbox:
 	ANSIBLE_SSH_PIPELINING=true ansible-playbook -i environments/vagrant/hosts \
 		--limit=macos_rust_slave \
 		--vault-password-file=~/.ansible/vault-pass \
@@ -339,16 +339,52 @@ provision-rust_slave-macos-mojave-x86_64-vagrant-vbox:
 		-e "cloud_environment=none" \
 		ansible/osx-rust-slave.yml
 
-provision-rust_slave-macos-mojave-x86_64-qa-aws:
-	./scripts/sh/run_ansible_against_mac_slave.sh "qa"
+provision-rust_slave-macos-high_sierra-x86_64-qa-aws:
+	./scripts/sh/run_ansible_against_mac_slave.sh "qa" "192.168.1.190"
 
-provision-rust_slave-macos-mojave-x86_64-staging-aws:
-	./scripts/sh/run_ansible_against_mac_slave.sh "staging"
+provision-from_external-rust_slave-macos-high_sierra-x86_64-qa-aws:
+ifndef MACOS_SLAVE_SSH_IP_ADDRESS
+	@echo "The MACOS_SLAVE_SSH_IP_ADDRESS environment variable must be set."
+	@exit 1
+endif
+ifndef MACOS_SLAVE_SSH_PORT
+	@echo "The MACOS_SLAVE_SSH_PORT environment variable must be set."
+	@exit 1
+endif
+	./scripts/sh/run_ansible_against_mac_slave.sh \
+		"qa" "${MACOS_SLAVE_SSH_IP_ADDRESS}" "${MACOS_SLAVE_SSH_PORT}"
 
-provision-rust_slave-macos-mojave-x86_64-prod-aws:
-	./scripts/sh/run_ansible_against_mac_slave.sh "prod"
+provision-rust_slave-macos-high_sierra-x86_64-staging-aws:
+	./scripts/sh/run_ansible_against_mac_slave.sh "staging" "192.168.1.190"
 
-clean-rust_slave-macos-mojave-x86_64:
+provision-from_external-rust_slave-macos-high_sierra-x86_64-staging-aws:
+ifndef MACOS_SLAVE_SSH_IP_ADDRESS
+	@echo "The MACOS_SLAVE_SSH_IP_ADDRESS environment variable must be set."
+	@exit 1
+endif
+ifndef MACOS_SLAVE_SSH_PORT
+	@echo "The MACOS_SLAVE_SSH_PORT environment variable must be set."
+	@exit 1
+endif
+	./scripts/sh/run_ansible_against_mac_slave.sh \
+		"staging" "${MACOS_SLAVE_SSH_IP_ADDRESS}" "${MACOS_SLAVE_SSH_PORT}"
+
+provision-rust_slave-macos-high_sierra-x86_64-prod-aws:
+	./scripts/sh/run_ansible_against_mac_slave.sh "prod" "192.168.1.190"
+
+provision-rust_slave-macos-high_sierra-x86_64-prod-aws:
+ifndef MACOS_SLAVE_SSH_IP_ADDRESS
+	@echo "The MACOS_SLAVE_SSH_IP_ADDRESS environment variable must be set."
+	@exit 1
+endif
+ifndef MACOS_SLAVE_SSH_PORT
+	@echo "The MACOS_SLAVE_SSH_PORT environment variable must be set."
+	@exit 1
+endif
+	./scripts/sh/run_ansible_against_mac_slave.sh \
+		"prod" "${MACOS_SLAVE_SSH_IP_ADDRESS}" "${MACOS_SLAVE_SSH_PORT}"
+
+clean-rust_slave-macos-high_sierra-x86_64:
 	ANSIBLE_PIPELINING=True ansible-playbook -i environments/vagrant/hosts ansible/osx-teardown.yml
 
 clean-vbox:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ It's possible to get an environment on AWS, but there is some setup required on 
 
 For the environment variables, it's probably better to put them in some kind of file and source that as part of your `~/.bashrc`.
 
+If you are working remotely, there are another couple of variables you may want to set if you need to provision the macOS slave:
+
+* Set `export MACOS_SLAVE_SSH_IP_ADDRESS=<value>`
+* Set `export MACOS_SLAVE_SSH_PORT=<value>`
+
+Both of these values can be obtained from someone in QA.
+
 #### Development Infrastructure
 
 To get the development environment run `make env-jenkins-dev-aws`. This creates:

--- a/ansible/docker-slave.yml
+++ b/ansible/docker-slave.yml
@@ -14,7 +14,7 @@
           group: "root",
           mode: 0755
         },
-        when: cloud_environment != "dev" or cloud_environment != "none"
+        when: cloud_environment != "dev"
       }
     - docker
     - jenkins-slave
@@ -27,6 +27,6 @@
           group: "jenkins",
           mode: 0755
         },
-        when: cloud_environment != "dev" or cloud_environment != "none"
+        when: cloud_environment != "dev"
       }
     - docker-slave-images

--- a/ansible/jenkins-master.yml
+++ b/ansible/jenkins-master.yml
@@ -12,7 +12,7 @@
           group: "root",
           mode: 0755
         },
-        when: cloud_environment != "dev" or cloud_environment != "none"
+        when: cloud_environment != "dev"
       }
     - {
         role: format_disk,
@@ -23,12 +23,12 @@
           group: "root",
           mode: 0755
         },
-        when: cloud_environment != "dev" or cloud_environment != "none"
+        when: cloud_environment != "dev"
       }
     - pip
     - docker
     - {
         role: wireguard-client,
-        when: cloud_environment != "dev" or cloud_environment != "none"
+        when: cloud_environment != "dev"
       }
     - jenkins-master

--- a/ansible/roles/docker-slave-images/defaults/main.yml
+++ b/ansible/roles/docker-slave-images/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 safe_client_libs_build_image_name: maidsafe/safe-client-libs-build
 safe_client_libs_build_image_tag: 0.9.1
+safe_nd_build_image_name: maidsafe/safe-nd-build
+safe_nd_build_image_tag: 0.1.0

--- a/ansible/roles/docker-slave-images/tasks/main.yml
+++ b/ansible/roles/docker-slave-images/tasks/main.yml
@@ -4,3 +4,4 @@
     name: "{{ item }}"
   with_items:
     - "{{ safe_client_libs_build_image_name }}:{{ safe_client_libs_build_image_tag }}"
+    - "{{ safe_nd_build_image_name }}:{{ safe_nd_build_image_tag }}"

--- a/ansible/roles/rust/tasks/main.yml
+++ b/ansible/roles/rust/tasks/main.yml
@@ -24,7 +24,7 @@
     - libssl-dev
     - pkg-config
   when: ansible_distribution == 'Ubuntu'
-  
+
 - name: 'get the rustup installer'
   get_url:
     url: "{{ rustup_installer_url }}"
@@ -61,6 +61,16 @@
   become: yes
   become_user: "{{ build_user }}"
   when: ansible_distribution != 'MacOSX'
+
+- name: 'install rustfmt'
+  command: "{{ rustup_path }} component add rustfmt"
+  become: yes
+  become_user: "{{ build_user }}"
+
+- name: 'install clippy'
+  command: "{{ rustup_path }} component add clippy"
+  become: yes
+  become_user: "{{ build_user }}"
 
 - stat: path="{{ cargo_script_path }}"
   register: cargo_script_result

--- a/ansible/roles/win-rust-slave/defaults/main.yml
+++ b/ansible/roles/win-rust-slave/defaults/main.yml
@@ -5,3 +5,4 @@ libsodium_version: 1.0.17
 libsodium_archive_name: "libsodium-{{ libsodium_version }}-mingw.tar.gz"
 libsodium_url: "https://download.libsodium.org/libsodium/releases/libsodium-{{ libsodium_version }}-mingw.tar.gz"
 libsodium_path: "C:\\libsodium-{{ libsodium_version }}"
+rustup_path: "C:\\Users\\{{ jenkins_service_account_user }}\\.cargo\\bin\\rustup"

--- a/ansible/roles/win-rust-slave/tasks/main.yml
+++ b/ansible/roles/win-rust-slave/tasks/main.yml
@@ -79,3 +79,17 @@
 - name: 'run the rust installer as the admin user'
   win_command: "powershell.exe -File C:\\Temp\\install_rustup.ps1"
   when: jenkins_service_account_user == ""
+
+- name: 'install rustfmt'
+  win_psexec:
+    command: "{{ rustup_path }} component add rustfmt"
+    elevated: yes
+    username: "{{ jenkins_service_account_user }}"
+    password: "{{ jenkins_service_account_password }}"
+
+- name: 'install clippy'
+  win_psexec:
+    command: "{{ rustup_path }} component add clippy"
+    elevated: yes
+    username: "{{ jenkins_service_account_user }}"
+    password: "{{ jenkins_service_account_password }}"

--- a/environments/dev/group_vars/all/vars.yml
+++ b/environments/dev/group_vars/all/vars.yml
@@ -5,7 +5,7 @@ jenkins_master_host_url: jenkins_master.ubuntu.local
 docker_slave_ip_address: 192.168.10.101
 docker_slave_full_name: docker_slave-ubuntu-bionic-x86_64
 docker_slave_host_url: docker-slave.ubuntu.local
-docker_slave_ami_id: ami-0c96a5161096cfd71
+docker_slave_ami_id: ami-0b4444936cd1d30ad
 windows_rust_slave_ip_address: 192.168.10.102
 windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.ubuntu.local

--- a/environments/dev/hosts
+++ b/environments/dev/hosts
@@ -8,10 +8,10 @@ jenkins_master
 windows_slave_001 ansible_become_pass="{{ ansible_password }}"
 
 [osx_slaves]
-macos_rust_slave ansible_host=192.168.1.190 ansible_user=qamaidsafe
+macos_rust_slave ansible_host="{{ macos_slave_ssh_hostname }}" ansible_user=qamaidsafe ansible_port="{{ macos_slave_ssh_port }}"
 
 [wireguard]
 jenkins_master
-macos_rust_slave ansible_host=192.168.1.190 ansible_user=qamaidsafe
+macos_rust_slave ansible_host="{{ macos_slave_ssh_hostname }}" ansible_user=qamaidsafe ansible_port="{{ macos_slave_ssh_port }}"
 wgserver
 wgclient-ubuntu-bionic-x86_64 ansible_host=localhost ansible_port=2322

--- a/environments/prod/group_vars/all/vars.yml
+++ b/environments/prod/group_vars/all/vars.yml
@@ -7,7 +7,7 @@ jenkins_master_host_url: jenkins_master.ubuntu.local
 docker_slave_ip_address: 192.168.10.101
 docker_slave_full_name: docker_slave-ubuntu-bionic-x86_64
 docker_slave_host_url: docker-slave.ubuntu.local
-docker_slave_ami_id: ami-0c96a5161096cfd71
+docker_slave_ami_id: ami-0b4444936cd1d30ad
 windows_rust_slave_ip_address: 192.168.10.102
 windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.ubuntu.local

--- a/environments/prod/hosts
+++ b/environments/prod/hosts
@@ -16,9 +16,9 @@ windows_slave_001 ansible_become_pass="{{ ansible_password }}"
 windows_slave_002 ansible_become_pass="{{ ansible_password }}"
 
 [osx_slaves]
-macos_rust_slave ansible_host=192.168.1.190 ansible_user=qamaidsafe
+macos_rust_slave ansible_host="{{ macos_slave_ssh_hostname }}" ansible_user=qamaidsafe ansible_port="{{ macos_slave_ssh_port }}"
 
 [wireguard]
 haproxy
 jenkins_master
-macos_rust_slave ansible_host=192.168.1.190 ansible_user=qamaidsafe
+macos_rust_slave ansible_host="{{ macos_slave_ssh_hostname }}" ansible_user=qamaidsafe ansible_port="{{ macos_slave_ssh_port }}"

--- a/environments/qa/group_vars/all/vars.yml
+++ b/environments/qa/group_vars/all/vars.yml
@@ -7,7 +7,7 @@ jenkins_master_host_url: jenkins_master.ubuntu.local
 docker_slave_ip_address: 192.168.10.101
 docker_slave_full_name: docker_slave-ubuntu-bionic-x86_64
 docker_slave_host_url: docker-slave.ubuntu.local
-docker_slave_ami_id: ami-03850277b53ba7bc5
+docker_slave_ami_id: ami-0b4444936cd1d30ad
 windows_rust_slave_ip_address: 192.168.10.102
 windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.ubuntu.local

--- a/environments/qa/hosts
+++ b/environments/qa/hosts
@@ -16,9 +16,9 @@ windows_slave_001 ansible_become_pass="{{ ansible_password }}"
 windows_slave_002 ansible_become_pass="{{ ansible_password }}"
 
 [osx_slaves]
-macos_rust_slave ansible_host=192.168.1.190 ansible_user=qamaidsafe
+macos_rust_slave ansible_host="{{ macos_slave_ssh_hostname }}" ansible_user=qamaidsafe ansible_port="{{ macos_slave_ssh_port }}"
 
 [wireguard]
 haproxy
 jenkins_master
-macos_rust_slave ansible_host=192.168.1.190 ansible_user=qamaidsafe
+macos_rust_slave ansible_host="{{ macos_slave_ssh_hostname }}" ansible_user=qamaidsafe ansible_port="{{ macos_slave_ssh_port }}"

--- a/environments/staging/group_vars/all/vars.yml
+++ b/environments/staging/group_vars/all/vars.yml
@@ -7,7 +7,7 @@ jenkins_master_host_url: jenkins_master.ubuntu.local
 docker_slave_ip_address: 192.168.10.101
 docker_slave_full_name: docker_slave-ubuntu-bionic-x86_64
 docker_slave_host_url: docker-slave.ubuntu.local
-docker_slave_ami_id: ami-0c96a5161096cfd71
+docker_slave_ami_id: ami-0b4444936cd1d30ad
 windows_rust_slave_ip_address: 192.168.10.102
 windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.ubuntu.local

--- a/environments/staging/hosts
+++ b/environments/staging/hosts
@@ -16,9 +16,9 @@ windows_slave_001 ansible_become_pass="{{ ansible_password }}"
 windows_slave_002 ansible_become_pass="{{ ansible_password }}"
 
 [osx_slaves]
-macos_rust_slave ansible_host=192.168.1.190 ansible_user=qamaidsafe
+macos_rust_slave ansible_host="{{ macos_slave_ssh_hostname }}" ansible_user=qamaidsafe ansible_port="{{ macos_slave_ssh_port }}"
 
 [wireguard]
 haproxy
 jenkins_master
-macos_rust_slave ansible_host=192.168.1.190 ansible_user=qamaidsafe
+macos_rust_slave ansible_host="{{ macos_slave_ssh_hostname }}" ansible_user=qamaidsafe ansible_port="{{ macos_slave_ssh_port }}"

--- a/scripts/sh/run_ansible_against_mac_slave.sh
+++ b/scripts/sh/run_ansible_against_mac_slave.sh
@@ -6,6 +6,17 @@ if [[ -z "$cloud_environment" ]]; then
     exit 1
 fi
 
+ssh_hostname=$2
+if [[ -z "$ssh_hostname" ]]; then
+    echo "A value must be supplied for the hostname. For running in the office use the internal IP, for running externally, use the external address."
+    exit 1
+fi
+
+ssh_port=$3
+if [[ -z "$ssh_port" ]]; then
+    ssh_port="22"
+fi
+
 function get_proxy_dns() {
     if [[ "$cloud_environment" == "prod" ]]; then
         proxy_dns="jenkins.maidsafe.net"
@@ -32,6 +43,8 @@ function run_ansible() {
         --limit=macos_rust_slave \
         --vault-password-file=~/.ansible/vault-pass \
         --private-key=~/.ssh/id_rsa \
+        -e "macos_slave_ssh_hostname=$ssh_hostname" \
+        -e "macos_slave_ssh_port=$ssh_port" \
         -e "wg_server_endpoint=$proxy_dns" \
         -e "cloud_environment=$cloud_environment" \
         -e "wg_run_on_host=True" \


### PR DESCRIPTION
Hi Stephen,

I've tested these changes on the dev environment. They are relatively low risk so I don't think they require a full staging test.

Issues dealt with:

* Closes #85 
* Closes #86 
* Closes #88
* Closes #89 

There is a new Docker slave AMI generated that has an updated container for SCL and the container for safe-nd. It also installs rustfmt and clippy on the macOS and Windows slaves.

As you know, we've already provisioned the macOS slave, so it will just be the Windows slave and the Docker slave AMI ID that will be updated.

Cheers,

Chris