### PR TITLE
Use S3 Backend for Terraform

### DIFF
--- a/terraform/dev/backend.tf
+++ b/terraform/dev/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "safe-terraform-state"
+    key = "dev.tfstate"
+    region = "eu-west-2"
+  }
+}

--- a/terraform/prod/backend.tf
+++ b/terraform/prod/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "safe-terraform-state"
+    key = "prod.tfstate"
+    region = "eu-west-2"
+  }
+}

--- a/terraform/qa/backend.tf
+++ b/terraform/qa/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "safe-terraform-state"
+    key = "qa.tfstate"
+    region = "eu-west-2"
+  }
+}

--- a/terraform/staging/backend.tf
+++ b/terraform/staging/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "safe-terraform-state"
+    key = "staging.tfstate"
+    region = "eu-west-2"
+  }
+}


### PR DESCRIPTION
Hi Stephen,

This migrates us over to using S3 for the tfstate files. This verification process is the last time we should need to copy around any state files.

Instructions:

* Clone a copy of the `maidsafe/safe-build-infrastructure` repo and leave it on the `master` branch
* Clone a copy of the `jacderida/safe-build-infrastructure` fork and switch to the `terraform_s3_backend` branch
* From the `master` branch of the `maidsafe/safe-build-infrastructure` do `cd terraform/staging && terraform init && terraform apply`
* Delete any pre-existing `.terraform` directory or `.tfstate` files in the `jacderida/safe-build-infrastructure` fork
* Copy the `terraform.tfstate` file resulting from the staging environment creation to the `jacderida/safe-build-infrastructure` repo and put it under `terraform/staging`
* From the `terraform_s3_backend` branch of the `jacderida/safe-build-infrastructure`:
  - `cd terraform/staging`
  - `terraform apply`
  - Terraform should say 'Backend reinitialization required. Please run "terraform init".'
  - `terraform init` and say yes to migrating the tfstate
* Move the local `terraform.tfstate` file somewhere else
* Run a `terraform plan` without the local tfstate file

Acceptance Critiera:

* The `staging.tf` file should be uploaded to `safe-terraform-state`.
* After moving the local .tfstate somewhere else, the `terraform plan` should say that no resources will be added.
  
If you confirm this works, the same steps will be followed to migrate prod.

Cheers,

Chris
