### PR TITLE
Update Docker Slave AMI

### DIFF
--- a/environments/dev/group_vars/all/vars.yml
+++ b/environments/dev/group_vars/all/vars.yml
@@ -5,7 +5,7 @@ jenkins_master_host_url: jenkins_master.ubuntu.local
 docker_slave_ip_address: 192.168.10.101
 docker_slave_full_name: docker_slave-ubuntu-bionic-x86_64
 docker_slave_host_url: docker-slave.ubuntu.local
-docker_slave_ami_id: ami-060e5d58b7533cfe3
+docker_slave_ami_id: ami-09213939f60112dee
 windows_rust_slave_ip_address: 192.168.10.102
 windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.ubuntu.local

--- a/environments/prod/group_vars/all/vars.yml
+++ b/environments/prod/group_vars/all/vars.yml
@@ -7,7 +7,7 @@ jenkins_master_host_url: jenkins_master.ubuntu.local
 docker_slave_ip_address: 192.168.10.101
 docker_slave_full_name: docker_slave-ubuntu-bionic-x86_64
 docker_slave_host_url: docker-slave.ubuntu.local
-docker_slave_ami_id: ami-060e5d58b7533cfe3
+docker_slave_ami_id: ami-09213939f60112dee
 windows_rust_slave_ip_address: 192.168.10.102
 windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.ubuntu.local

--- a/environments/qa/group_vars/all/vars.yml
+++ b/environments/qa/group_vars/all/vars.yml
@@ -7,7 +7,7 @@ jenkins_master_host_url: jenkins_master.ubuntu.local
 docker_slave_ip_address: 192.168.10.101
 docker_slave_full_name: docker_slave-ubuntu-bionic-x86_64
 docker_slave_host_url: docker-slave.ubuntu.local
-docker_slave_ami_id: ami-060e5d58b7533cfe3
+docker_slave_ami_id: ami-09213939f60112dee
 windows_rust_slave_ip_address: 192.168.10.102
 windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.ubuntu.local

--- a/environments/staging/group_vars/all/vars.yml
+++ b/environments/staging/group_vars/all/vars.yml
@@ -7,7 +7,7 @@ jenkins_master_host_url: jenkins_master.ubuntu.local
 docker_slave_ip_address: 192.168.10.101
 docker_slave_full_name: docker_slave-ubuntu-bionic-x86_64
 docker_slave_host_url: docker-slave.ubuntu.local
-docker_slave_ami_id: ami-060e5d58b7533cfe3
+docker_slave_ami_id: ami-09213939f60112dee
 windows_rust_slave_ip_address: 192.168.10.102
 windows_rust_slave_full_name: rust_slave-windows-2016-x86_64
 windows_rust_slave_host_url: rust_slave.ubuntu.local


### PR DESCRIPTION
New AMI has containers updated with new user IDs that should remove fixuid having to run.