### PR TITLE
Change Ansible Version

### DIFF
--- a/ansible/roles/ansible-provisioner/defaults/main.yml
+++ b/ansible/roles/ansible-provisioner/defaults/main.yml
@@ -5,3 +5,4 @@ virtualenv_path: "/home/{{ provisioning_user }}/.venv"
 provisioning_virtualenv_path: "{{ virtualenv_path }}/{{ virtualenv_name }}"
 jq_url: "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64"
 jq_install_path: "/usr/local/bin/jq"
+ansible_provisioner_version: 2.8.2

--- a/ansible/roles/ansible-provisioner/tasks/main.yml
+++ b/ansible/roles/ansible-provisioner/tasks/main.yml
@@ -76,13 +76,13 @@
 
 # You are supposed to be able to use the 'virtualenv' parameter of the pip module to
 # install packages into a virtualenv, but it wasn't working correctly.
-- name: 'install ansible, boto and pypsrp in virtualenv'
+- name: 'install ansible dependencies'
   shell: |
     . {{ provisioning_virtualenv_path }}/bin/activate
     pip install {{ item }}
   with_items:
     - awscli
-    - git+https://github.com/ansible/ansible.git@devel
+    - "ansible=={{ ansible_provisioner_version }}"
     - boto
     - boto3
     - pypsrp


### PR DESCRIPTION
We started seeing some issues with the latest development branch.
Although version 2.8.2 is not a stable release, the stable release is
too old. This version should be more stable than pulling straight from
development, and it resolves the issue I had yesterday where you didn't
seem to be able to use a `with_items` loop without Ansible
disconnecting.