### PR TITLE
Upgrade Rust Stable 

### DIFF
--- a/ansible/roles/rust/tasks/main.yml
+++ b/ansible/roles/rust/tasks/main.yml
@@ -56,6 +56,11 @@
   become_user: "{{ build_user }}"
   when: rust_path_result.stat.exists == False
 
+- name: 'update to the latest stable version'
+  command: "{{ rustup_path }} update {{ rust_version }}"
+  become: yes
+  become_user: "{{ build_user }}"
+
 - name: 'add musl target'
   command: "{{ rustup_path }} target add x86_64-unknown-linux-musl"
   become: yes

--- a/ansible/roles/win-rust-slave/tasks/main.yml
+++ b/ansible/roles/win-rust-slave/tasks/main.yml
@@ -87,6 +87,13 @@
     username: "{{ jenkins_service_account_user }}"
     password: "{{ jenkins_service_account_password }}"
 
+- name: 'update to the latest stable version'
+  win_psexec:
+    command: "{{ rustup_path }} update {{ rust_version }}"
+    elevated: yes
+    username: "{{ jenkins_service_account_user }}"
+    password: "{{ jenkins_service_account_password }}"
+
 - name: 'install clippy'
   win_psexec:
     command: "{{ rustup_path }} component add clippy"


### PR DESCRIPTION
Given that it's backward compatible, this changes things so that any time we run a provision, we will just grab whatever the latest stable version is.