### PR TITLE
feat/role: add zip package to docker slave

### DIFF
--- a/ansible/roles/docker-slave/tasks/main.yml
+++ b/ansible/roles/docker-slave/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: 'install zip package for artifact distribution'
+  package:
+    name: "zip"
+    state: present
+
 - name: 'copy dockerhub password'
   copy:
     dest: "/home/{{ build_user }}/docker_password.txt"


### PR DESCRIPTION
Since we decided to use zips rather than tars, we need the zip tool on the slave. Unfortunately it's not installed on CentOS 7.6 by default.