### PR TITLE
feat/role: mobile targets for iOS

### DIFF
--- a/ansible/roles/rust/tasks/main.yml
+++ b/ansible/roles/rust/tasks/main.yml
@@ -67,6 +67,15 @@
   become_user: "{{ build_user }}"
   when: ansible_distribution != 'MacOSX'
 
+- name: 'add iOS targets'
+  command: "{{ rustup_path }} target add {{ item }}"
+  become: yes
+  become_user: "{{ build_user }}"
+  with_items:
+    - aarch64-apple-ios
+    - x86_64-apple-ios
+  when: ansible_distribution == 'MacOSX'
+
 - name: 'install rustfmt'
   command: "{{ rustup_path }} component add rustfmt"
   become: yes


### PR DESCRIPTION
I considered splitting this out into a separate `rust-mobile` role, but I think it's overkill. It doesn't really hurt too much to have a target installed anyway, even if this particular machine wouldn't be used for
building mobile stuff.