### PR TITLE
refactor/slave: extra disk space for docker

### DIFF
--- a/templates/docker_slave-centos-7.6-x86_64.json
+++ b/templates/docker_slave-centos-7.6-x86_64.json
@@ -38,7 +38,7 @@
         },
         {
           "device_name": "/dev/sdc",
-          "volume_size": 50,
+          "volume_size": 100,
           "volume_type": "gp2",
           "encrypted": false,
           "delete_on_termination": true
@@ -47,7 +47,7 @@
       "launch_block_device_mappings": [
         {
           "device_name": "/dev/sdb",
-          "volume_size": 50,
+          "volume_size": 100,
           "volume_type": "gp2",
           "encrypted": false,
           "delete_on_termination": true


### PR DESCRIPTION
The Android containers are actually quite large at around 12GB. There
are 4 of these, plus the 2 x86_64 containers that around about 2GB each,
so 50GB isn't going to be enough space.