### PR TITLE
chore/slave: increase macOS executors to 3

### DIFF
--- a/ansible/roles/jenkins-master/tasks/main.yml
+++ b/ansible/roles/jenkins-master/tasks/main.yml
@@ -202,7 +202,7 @@
   cron:
     name: backup_jenkins
     day: "*"
-    hour: 2
+    hour: 1
     minute: 0
     job: "{{ backup_script_path }}"
 

--- a/ansible/roles/jenkins-master/templates/jenkins.yml
+++ b/ansible/roles/jenkins-master/templates/jenkins.yml
@@ -294,7 +294,7 @@ jenkins:
             retryWaitTime: 15
         name: "{{ osx_rust_slave_full_name }}"
         labelString: "osx"
-        numExecutors: 2
+        numExecutors: 3
         remoteFS: "{{ macos_jenkins_workspace }}"
 {% endif %}
 {% else %}


### PR DESCRIPTION
Due to mobile stuff now being built in Jenkins, we have lots of jobs that
need to run on macOS. Not sure what the effect will be of enabling this
extra executor, in terms of whether it would slow the machine down too
much and we wouldn't be able to see much time improvement from just
using 2 executors.

Also changes the time of the Jenkins backup job to 1AM, since we are
planning on running a bunch of nightly builds at 2AM, so we obviously
want that to be done first.