### PR TITLE
fix/slave: delete root volume on termination

### DIFF
--- a/ansible/roles/jenkins-master/templates/jenkins.yml
+++ b/ansible/roles/jenkins-master/templates/jenkins.yml
@@ -70,7 +70,7 @@ jenkins:
             associatePublicIp: false
             connectBySSHProcess: false
             connectUsingPublicIp: false
-            deleteRootOnTermination: false
+            deleteRootOnTermination: true
             description: "{{ docker_slave_full_name }}"
             ebsOptimized: false
             idleTerminationMinutes: "30"
@@ -95,7 +95,7 @@ jenkins:
             associatePublicIp: false
             connectBySSHProcess: false
             connectUsingPublicIp: false
-            deleteRootOnTermination: false
+            deleteRootOnTermination: true
             description: "{{ safe_client_libs_docker_slave_full_name }}"
             ebsOptimized: false
             idleTerminationMinutes: "30"
@@ -120,7 +120,7 @@ jenkins:
             associatePublicIp: false
             connectBySSHProcess: false
             connectUsingPublicIp: false
-            deleteRootOnTermination: false
+            deleteRootOnTermination: true
             description: "{{ safe_cli_docker_slave_full_name }}"
             ebsOptimized: false
             idleTerminationMinutes: "30"
@@ -145,7 +145,7 @@ jenkins:
             associatePublicIp: false
             connectBySSHProcess: false
             connectUsingPublicIp: false
-            deleteRootOnTermination: false
+            deleteRootOnTermination: true
             description: "{{ safe_nd_docker_slave_full_name }}"
             ebsOptimized: false
             idleTerminationMinutes: "30"
@@ -170,7 +170,7 @@ jenkins:
             associatePublicIp: false
             connectBySSHProcess: false
             connectUsingPublicIp: false
-            deleteRootOnTermination: false
+            deleteRootOnTermination: true
             description: "{{ safe_vault_docker_slave_full_name }}"
             ebsOptimized: false
             idleTerminationMinutes: "30"
@@ -195,7 +195,7 @@ jenkins:
             associatePublicIp: false
             connectBySSHProcess: false
             connectUsingPublicIp: false
-            deleteRootOnTermination: false
+            deleteRootOnTermination: true
             description: "{{ safe_auth_cli_docker_slave_full_name }}"
             ebsOptimized: false
             idleTerminationMinutes: "30"
@@ -229,7 +229,7 @@ jenkins:
             associatePublicIp: false
             connectBySSHProcess: false
             connectUsingPublicIp: false
-            deleteRootOnTermination: false
+            deleteRootOnTermination: true
             description: "{{ util_slave_full_name }}"
             ebsOptimized: false
             idleTerminationMinutes: "30"

--- a/templates/docker_slave-centos-7.6-x86_64.json
+++ b/templates/docker_slave-centos-7.6-x86_64.json
@@ -31,7 +31,7 @@
       "ami_block_device_mappings": [
         {
           "device_name": "/dev/sdb",
-          "volume_size": 50,
+          "volume_size": 100,
           "volume_type": "gp2",
           "encrypted": false,
           "delete_on_termination": true
@@ -54,7 +54,7 @@
         },
         {
           "device_name": "/dev/sdc",
-          "volume_size": 50,
+          "volume_size": 100,
           "volume_type": "gp2",
           "encrypted": false,
           "delete_on_termination": true


### PR DESCRIPTION
Not having this setting applied was causing EBS costs to balloon again. Any slave that was launched was having its 8gb root volume retained after it was terminated.

This also extends the disk size of the Docker storage volume on the slave AMI because when you have a configuration with a lot of containers (like safe-cli) it can sometimes run out of space.