### PR TITLE
chore/slave: decrease idle time

### DIFF
--- a/ansible/roles/jenkins-master/templates/jenkins.yml
+++ b/ansible/roles/jenkins-master/templates/jenkins.yml
@@ -73,7 +73,7 @@ jenkins:
             deleteRootOnTermination: true
             description: "{{ docker_slave_full_name }}"
             ebsOptimized: false
-            idleTerminationMinutes: "30"
+            idleTerminationMinutes: "10"
             labelString: "docker"
             mode: NORMAL
             monitoring: false
@@ -98,7 +98,7 @@ jenkins:
             deleteRootOnTermination: true
             description: "{{ safe_client_libs_docker_slave_full_name }}"
             ebsOptimized: false
-            idleTerminationMinutes: "30"
+            idleTerminationMinutes: "10"
             labelString: "safe_client_libs"
             mode: NORMAL
             monitoring: false
@@ -123,7 +123,7 @@ jenkins:
             deleteRootOnTermination: true
             description: "{{ safe_cli_docker_slave_full_name }}"
             ebsOptimized: false
-            idleTerminationMinutes: "30"
+            idleTerminationMinutes: "10"
             labelString: "safe_cli"
             mode: NORMAL
             monitoring: false
@@ -148,7 +148,7 @@ jenkins:
             deleteRootOnTermination: true
             description: "{{ safe_nd_docker_slave_full_name }}"
             ebsOptimized: false
-            idleTerminationMinutes: "30"
+            idleTerminationMinutes: "10"
             labelString: "safe_nd"
             mode: NORMAL
             monitoring: false
@@ -173,7 +173,7 @@ jenkins:
             deleteRootOnTermination: true
             description: "{{ safe_vault_docker_slave_full_name }}"
             ebsOptimized: false
-            idleTerminationMinutes: "30"
+            idleTerminationMinutes: "10"
             labelString: "safe_vault"
             mode: NORMAL
             monitoring: false
@@ -198,7 +198,7 @@ jenkins:
             deleteRootOnTermination: true
             description: "{{ safe_auth_cli_docker_slave_full_name }}"
             ebsOptimized: false
-            idleTerminationMinutes: "30"
+            idleTerminationMinutes: "10"
             labelString: "safe_auth"
             mode: NORMAL
             monitoring: false
@@ -232,7 +232,7 @@ jenkins:
             deleteRootOnTermination: true
             description: "{{ util_slave_full_name }}"
             ebsOptimized: false
-            idleTerminationMinutes: "30"
+            idleTerminationMinutes: "10"
             labelString: "util"
             mode: NORMAL
             monitoring: false


### PR DESCRIPTION
We've found our AWS bill getting a bit expensive sometimes, so we've agreed to decrease the idle time from 30 minutes to 10 minutes. Some build configurations spin up quite a lot of Linux slaves, so this should hopefully decrease the overall time by quite a bit.