### PR TITLE
chore/env: create safe-client-libs bucket

### DIFF
--- a/terraform/common/common.tf
+++ b/terraform/common/common.tf
@@ -87,6 +87,11 @@ resource "aws_s3_bucket" "safe_auth_cli_deploy" {
   acl = "public-read"
 }
 
+resource "aws_s3_bucket" "safe_client_libs_deploy" {
+  bucket = "${var.safe_client_libs_deploy_bucket_name}"
+  acl = "public-read"
+}
+
 resource "aws_iam_user_policy" "jenkins_deploy_artifacts" {
     name = "jenkins_deploy_artifacts_user_policy"
     user = "${data.aws_iam_user.jenkins_deploy_artifacts.user_name}"
@@ -103,7 +108,9 @@ resource "aws_iam_user_policy" "jenkins_deploy_artifacts" {
                 "arn:aws:s3:::${aws_s3_bucket.safe_vault_deploy.bucket}",
                 "arn:aws:s3:::${aws_s3_bucket.safe_vault_deploy.bucket}/*",
                 "arn:aws:s3:::${aws_s3_bucket.safe_auth_cli_deploy.bucket}",
-                "arn:aws:s3:::${aws_s3_bucket.safe_auth_cli_deploy.bucket}/*"
+                "arn:aws:s3:::${aws_s3_bucket.safe_auth_cli_deploy.bucket}/*",
+                "arn:aws:s3:::${aws_s3_bucket.safe_client_libs_deploy.bucket}",
+                "arn:aws:s3:::${aws_s3_bucket.safe_client_libs_deploy.bucket}/*"
             ]
         }
    ]

--- a/terraform/common/variables.tf
+++ b/terraform/common/variables.tf
@@ -47,3 +47,8 @@ variable "safe_auth_cli_deploy_bucket_name" {
   default = "safe-authenticator-cli"
   description = "Name for bucket to deploy safe-authenticator-cli binaries to."
 }
+
+variable "safe_client_libs_deploy_bucket_name" {
+  default = "safe-client-libs"
+  description = "Name for bucket to deploy safe_client_libs binaries to."
+}


### PR DESCRIPTION
This bucket was previously created manually and there seemed to be some problems with the permissions. We are re-creating it here in code.